### PR TITLE
Shotgun cultist hitscan attacks do far more damage than intended

### DIFF
--- a/TCOTD2/decorate/tcotd2monsters.dec
+++ b/TCOTD2/decorate/tcotd2monsters.dec
@@ -818,22 +818,10 @@ ACTOR ShotgunCultistNew : TommyGunCultistNew 29010
      A_PlaySound("shotguy/attack");
 	 if (GetCVar("dvds_shotgunnerspread") == 0) { A_SetUserVar("user_pelletsfired",3); } else { A_SetUserVar("user_pelletsfired",7); }
 
-	  if (GetCVar("dvds_monsterbulletstracers") == 0) // Hitscan
-	  {
-	   A_CustomBulletAttack (user_shotaccuracy, user_shotzaccuracy, 3, (Random(4,6) * Random(1,2)), "BulletPuff", 0, 1);
-	  }
-	  else
-	  {
-       for (A_SetUserVar(user_currenttracer, 0); user_currenttracer < user_pelletsfired; A_SetUserVar(user_currenttracer, user_currenttracer + 1))
-       {
-        A_CustomMissile("TCOTDBulletTracer", 32, 12, frandom(user_shotaccuracy1,user_shotaccuracy2), CMF_OFFSETPITCH, frandom(user_shotzaccuracy1,user_shotzaccuracy2));       
-	   }	   
-	  }
-
 	 A_MonsterCrisisCheck;
 	 if (GetCVar("dvds_monsterbulletstracers") == 0) // Hitscan
 	 {
-	  A_CrisisBulletAttack(user_shotaccuracy, user_shotzaccuracy, 3, ((Random(4,6) * Random(1,2)) * CallACS("CrisisMultiplier")), "BulletPuff", 0, 1);
+	  A_CrisisBulletAttack(user_shotaccuracy, user_shotzaccuracy, user_pelletsfired, Random(4,6) * Random(1,2), "BulletPuff", 0, CBAF_AIMFACING|CBAF_NORANDOM);
 	 }
 	 else
 	 {


### PR DESCRIPTION
When monster bullets are hitscans, shotgun cultists do 1000+ damage per shot. I looked at the code and discovered why. This PR fixes it.